### PR TITLE
Prefab fixes

### DIFF
--- a/Assets/BlackScript.cs
+++ b/Assets/BlackScript.cs
@@ -16,7 +16,7 @@ public class BlackScript : BlackWhiteScript
 
 	private new void Start()
 	{
-		Start();
+		base.Start();
 		for (int i = 0; i < _buttons.Length; i++)
 		{
 			int j = i;

--- a/Assets/BlackWhiteScript.cs
+++ b/Assets/BlackWhiteScript.cs
@@ -30,14 +30,10 @@ public abstract class BlackWhiteScript : MonoBehaviour
 	{
 		Audio = GetComponent<KMAudio>();
 		Module = GetComponent<KMNeedyModule>();
-		KMNeedyModule module = Module;
-		module.OnActivate = (KMNeedyModule.KMModuleActivateEvent)Delegate.Combine(module.OnActivate, new KMNeedyModule.KMModuleActivateEvent(Activate));
-		KMNeedyModule module2 = Module;
-		module2.OnNeedyActivation = (KMNeedyModule.KMNeedyActivationEvent)Delegate.Combine(module2.OnNeedyActivation, new KMNeedyModule.KMNeedyActivationEvent(NeedyStart));
-		KMNeedyModule module3 = Module;
-		module3.OnTimerExpired = (KMNeedyModule.KMTimerExpiredEvent)Delegate.Combine(module3.OnTimerExpired, new KMNeedyModule.KMTimerExpiredEvent(NeedyEnd));
-		KMNeedyModule module4 = Module;
-		module4.OnNeedyDeactivation = (KMNeedyModule.KMNeedyDeactivationEvent)Delegate.Combine(module4.OnNeedyDeactivation, new KMNeedyModule.KMNeedyDeactivationEvent(BombOver));
+		Module.OnActivate += Activate;
+		Module.OnNeedyActivation += NeedyStart;
+		Module.OnTimerExpired += NeedyEnd;
+		Module.OnNeedyDeactivation += BombOver;
 		NeedyComponent = gameObject.GetComponent(ReflectionHelper.FindTypeInGame("ModNeedyComponent"));
 	}
 

--- a/Assets/BlackWhiteService.prefab
+++ b/Assets/BlackWhiteService.prefab
@@ -30,7 +30,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1015183657475334
 GameObject:
   m_ObjectHideFlags: 1
@@ -643,7 +643,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1545524291045502
 GameObject:
   m_ObjectHideFlags: 1
@@ -669,6 +669,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4778984697893548}
   - component: {fileID: 114520422993756138}
+  - component: {fileID: 114569543818230096}
   m_Layer: 0
   m_Name: BlackWhiteService
   m_TagString: Untagged
@@ -3998,12 +3999,12 @@ MonoBehaviour:
   m_Script: {fileID: 1718998123, guid: 45b809be76fd7a3468b6f517bced6f28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CountdownTime: 40
+  CountdownTime: 45
   ResetDelayMin: 10
   ResetDelayMax: 40
   ModuleType: blackModule
   ModuleDisplayName: Black
-  RequiresTimerVisibility: 0
+  RequiresTimerVisibility: 1
   WarnAtFiveSeconds: 1
 --- !u!114 &114127774309212200
 MonoBehaviour:
@@ -4266,7 +4267,7 @@ MonoBehaviour:
   Children: []
   IsPassThrough: 0
   ChildRowLength: 0
-  Highlight: {fileID: 0}
+  Highlight: {fileID: 114036543674081736}
   SelectableColliders:
   - {fileID: 65837375719820632}
   DefaultSelectableIndex: 0
@@ -4464,13 +4465,13 @@ MonoBehaviour:
   m_Script: {fileID: 1718998123, guid: 45b809be76fd7a3468b6f517bced6f28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CountdownTime: 40
+  CountdownTime: 45
   ResetDelayMin: 10
   ResetDelayMax: 40
   ModuleType: whiteModule
   ModuleDisplayName: White
   RequiresTimerVisibility: 0
-  WarnAtFiveSeconds: 1
+  WarnAtFiveSeconds: 0
 --- !u!114 &114553763882419370
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -4533,6 +4534,17 @@ MonoBehaviour:
   AllowSelectionWrapY: 0
   ForceSelectionHighlight: 0
   ForceInteractionHighlight: 0
+--- !u!114 &114569543818230096
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1563462215332494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1453678656, guid: 45b809be76fd7a3468b6f517bced6f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114576192319959566
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -4545,8 +4557,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _identifier: {fileID: 102043996118695438}
-  Partner: {fileID: 114709422286888702}
-  Module: {fileID: 114089799059524248}
+  Partner: {fileID: 0}
+  Module: {fileID: 0}
   _buttons:
   - {fileID: 114166747068019784}
   - {fileID: 114788997776154766}
@@ -4688,8 +4700,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _identifier: {fileID: 102728058095009788}
-  Partner: {fileID: 114576192319959566}
-  Module: {fileID: 114548746876696450}
+  Partner: {fileID: 0}
+  Module: {fileID: 0}
   Lights:
   - {fileID: 114414953341831140}
   - {fileID: 114349667684563426}


### PR DESCRIPTION
- Fix KMNeedyModule values
- Add KMService component
- Fix BlackScript/WhiteScript values. (Partner and Module are empty in the original, and I imagine a null check is used to decide if they need to be assigned or not)
- Fix White's invisible button not having a highlightable component, which really screws up interaction if you accidentally click it
- Hide White and Black so the game can properly instantiate them
- Fix a Stack Overflow in BlackScript
- Why are there four different things being assigned to the KMNeedyModule On methods. They don't need to be there.